### PR TITLE
fix: selecting patches crashes on android 10

### DIFF
--- a/app/src/main/java/app/revanced/manager/patcher/PatcherUtils.kt
+++ b/app/src/main/java/app/revanced/manager/patcher/PatcherUtils.kt
@@ -21,6 +21,7 @@ class PatcherUtils(val app: Application) {
     val patches = mutableStateOf<Resource<List<Class<out Patch<Context>>>>>(Resource.Loading)
     val filteredPatches = mutableStateListOf<PatchClass>()
     val selectedAppPackage = mutableStateOf(Optional.empty<ApplicationInfo>())
+    val selectedAppPackagePath = mutableStateOf<String?>(null)
     val selectedPatches = mutableStateListOf<String>()
     lateinit var patchBundleFile: String
 
@@ -48,8 +49,9 @@ class PatcherUtils(val app: Application) {
 
     fun getSelectedPackageInfo(): PackageInfo? {
         return if (selectedAppPackage.value.isPresent) {
+            val path = selectedAppPackage.value.get().publicSourceDir ?: selectedAppPackagePath.value ?: return null
             app.packageManager.getPackageArchiveInfo(
-                selectedAppPackage.value.get().publicSourceDir, 1
+                path, 1
             )
         } else {
             null

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/AppSelectorViewModel.kt
@@ -27,6 +27,7 @@ class AppSelectorViewModel(
     val patches = patcherUtils.patches
     private val filteredPatches = patcherUtils.filteredPatches
     private val selectedAppPackage = patcherUtils.selectedAppPackage
+    private val selectedAppPackagePath = patcherUtils.selectedAppPackagePath
     private val selectedPatches = patcherUtils.selectedPatches
 
     init {
@@ -64,7 +65,7 @@ class AppSelectorViewModel(
         return app.packageManager.getApplicationIcon(info)
     }
 
-    fun setSelectedAppPackage(appId: ApplicationInfo) {
+    fun setSelectedAppPackage(appId: ApplicationInfo, appPackagePath: String? = null) {
         selectedAppPackage.value.ifPresent { s ->
             if (s != appId) {
                 selectedPatches.clear()
@@ -72,6 +73,7 @@ class AppSelectorViewModel(
             }
         }
         selectedAppPackage.value = Optional.of(appId)
+        selectedAppPackagePath.value = appPackagePath
     }
 
     fun setSelectedAppPackageFromFile(file: Uri?) {
@@ -84,7 +86,8 @@ class AppSelectorViewModel(
             setSelectedAppPackage(
                 app.packageManager.getPackageArchiveInfo(
                     apkDir.path, 1
-                )!!.applicationInfo
+                )!!.applicationInfo,
+                apkDir.absolutePath
             )
         } catch (e: Exception) {
             Log.e(tag, "Failed to load apk", e)

--- a/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchingScreenViewModel.kt
+++ b/app/src/main/java/app/revanced/manager/ui/viewmodel/PatchingScreenViewModel.kt
@@ -131,6 +131,7 @@ class PatchingScreenViewModel(
             val reVancedFolder =
                 Environment.getExternalStorageDirectory().resolve("ReVanced").also { it.mkdirs() }
             val appInfo = patcherUtils.selectedAppPackage.value.get()
+            val appPath = patcherUtils.selectedAppPackagePath.value
 
             log(PatchLog.Info("Checking prerequisites..."))
             val patches = patcherUtils.findPatchesByIds(patcherUtils.selectedPatches)
@@ -146,7 +147,7 @@ class PatchingScreenViewModel(
             log(PatchLog.Info("Copying APK from device..."))
             withContext(Dispatchers.IO) {
                 Files.copy(
-                    File(appInfo.publicSourceDir).toPath(),
+                    File(appPath ?: appInfo.publicSourceDir).toPath(),
                     inputFile.toPath(),
                     StandardCopyOption.REPLACE_EXISTING
                 )


### PR DESCRIPTION
`ApplicationInfo.publicSourceDir` was returning null for some reason. This PR creates another variable to store apk file path and uses it when `publicSourceDir` is null.
Tested on Android 10 device with youtube (as apk) and twitter (from app list)