### PR TITLE
fix: pass worker inputs without serialization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,7 +91,6 @@ dependencies {
     // KotlinX
     val serializationVersion = "1.5.1"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$serializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
 
     // Room

--- a/app/src/main/java/app/revanced/manager/di/RepositoryModule.kt
+++ b/app/src/main/java/app/revanced/manager/di/RepositoryModule.kt
@@ -5,6 +5,7 @@ import app.revanced.manager.domain.repository.ReVancedRepository
 import app.revanced.manager.network.api.ManagerAPI
 import app.revanced.manager.domain.repository.SourcePersistenceRepository
 import app.revanced.manager.domain.repository.SourceRepository
+import app.revanced.manager.domain.worker.WorkerRepository
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
@@ -14,4 +15,5 @@ val repositoryModule = module {
     singleOf(::SourcePersistenceRepository)
     singleOf(::PatchSelectionRepository)
     singleOf(::SourceRepository)
+    singleOf(::WorkerRepository)
 }

--- a/app/src/main/java/app/revanced/manager/domain/worker/Worker.kt
+++ b/app/src/main/java/app/revanced/manager/domain/worker/Worker.kt
@@ -1,0 +1,7 @@
+package app.revanced.manager.domain.worker
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+abstract class Worker<ARGS>(context: Context, parameters: WorkerParameters) : CoroutineWorker(context, parameters)

--- a/app/src/main/java/app/revanced/manager/domain/worker/WorkerRepository.kt
+++ b/app/src/main/java/app/revanced/manager/domain/worker/WorkerRepository.kt
@@ -1,0 +1,36 @@
+package app.revanced.manager.domain.worker
+
+import android.app.Application
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import java.util.UUID
+
+class WorkerRepository(app: Application) {
+    val workManager = WorkManager.getInstance(app)
+
+    /**
+     * The standard WorkManager communication APIs use [androidx.work.Data], which has too many limitations.
+     * We can get around those limits by passing inputs using global variables instead.
+     */
+    val workerInputs = mutableMapOf<UUID, Any>()
+
+    @Suppress("UNCHECKED_CAST")
+    fun <A : Any, W : Worker<A>> claimInput(worker: W): A {
+        val data = workerInputs[worker.id] ?: throw IllegalStateException("Worker was not launched via WorkerRepository")
+        workerInputs.remove(worker.id)
+
+        return data as A
+    }
+
+    inline fun <reified W : Worker<A>, A : Any> launchExpedited(name: String, input: A): UUID {
+        val request =
+            OneTimeWorkRequest.Builder(W::class.java) // create Worker
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
+        workerInputs[request.id] = input
+        workManager.enqueueUniqueWork(name, ExistingWorkPolicy.REPLACE, request)
+        return request.id
+    }
+}

--- a/app/src/main/java/app/revanced/manager/ui/screen/InstallerScreen.kt
+++ b/app/src/main/java/app/revanced/manager/ui/screen/InstallerScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.*
@@ -33,6 +31,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.revanced.manager.R
 import app.revanced.manager.patcher.worker.Step
 import app.revanced.manager.patcher.worker.State
@@ -41,7 +40,6 @@ import app.revanced.manager.ui.component.AppTopBar
 import app.revanced.manager.ui.component.ArrowButton
 import app.revanced.manager.ui.viewmodel.InstallerViewModel
 import app.revanced.manager.util.APK_MIMETYPE
-import kotlin.math.exp
 import kotlin.math.floor
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -52,8 +50,9 @@ fun InstallerScreen(
 ) {
     val exportApkLauncher =
         rememberLauncherForActivityResult(CreateDocument(APK_MIMETYPE), vm::export)
-    val patcherState by vm.patcherState.observeAsState(vm.initialState)
-    val canInstall by remember { derivedStateOf { patcherState.succeeded == true && (vm.installedPackageName != null || !vm.isInstalling) } }
+    val patcherState by vm.patcherState.observeAsState(null)
+    val steps by vm.progress.collectAsStateWithLifecycle()
+    val canInstall by remember { derivedStateOf { patcherState == true && (vm.installedPackageName != null || !vm.isInstalling) } }
 
     AppScaffold(
         topBar = {
@@ -77,7 +76,7 @@ fun InstallerScreen(
                 .verticalScroll(rememberScrollState())
                 .fillMaxSize()
         ) {
-            patcherState.steps.forEach {
+            steps.forEach {
                 InstallStep(it)
             }
             Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/app/revanced/manager/util/Util.kt
+++ b/app/src/main/java/app/revanced/manager/util/Util.kt
@@ -12,8 +12,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import androidx.work.Data
-import androidx.work.workDataOf
 import io.ktor.http.Url
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,10 +19,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.cbor.Cbor
-import kotlinx.serialization.decodeFromByteArray
-import kotlinx.serialization.encodeToByteArray
 
 typealias PatchesSelection = Map<Int, List<String>>
 
@@ -99,13 +93,3 @@ inline fun <T, reified R, C> Flow<Iterable<T>>.flatMapLatestAndCombine(
         combiner(it)
     }
 }
-
-const val workDataKey = "payload"
-
-@OptIn(ExperimentalSerializationApi::class)
-inline fun <reified T> T.serialize(): Data =
-    workDataOf(workDataKey to Cbor.Default.encodeToByteArray(this))
-
-@OptIn(ExperimentalSerializationApi::class)
-inline fun <reified T> Data.deserialize(): T? =
-    getByteArray(workDataKey)?.let { Cbor.Default.decodeFromByteArray(it) }


### PR DESCRIPTION
Because `androidx.work.Data` sucks and causes our app to crash.