### PR TITLE
fix: only download non-bundled APKs

### DIFF
--- a/app/src/main/java/app/revanced/manager/network/downloader/APKMirror.kt
+++ b/app/src/main/java/app/revanced/manager/network/downloader/APKMirror.kt
@@ -211,7 +211,7 @@ class APKMirror : AppDownloader, KoinComponent {
 
             val variant = orderedAPKTypes.firstNotNullOfOrNull { apkType ->
                 supportedArches.firstNotNullOfOrNull { arch ->
-                    variants.find { it.arch == arch && it.apkType == apkType }
+                    variants.find { it.arch == arch && it.apkType == APKType.APK } // TEMPORARY: Only accept APKType.APK since Bundles are not currently supported; replace APKType.APK with apkType once bundles are supported
                 }
             } ?: throw Exception("No compatible variant found")
 

--- a/app/src/main/java/app/revanced/manager/network/downloader/APKMirror.kt
+++ b/app/src/main/java/app/revanced/manager/network/downloader/APKMirror.kt
@@ -206,12 +206,12 @@ class APKMirror : AppDownloader, KoinComponent {
                     }
                 }
 
-            val orderedAPKTypes = mutableListOf(APKType.APK, APKType.BUNDLE)
+            val orderedAPKTypes = mutableListOf(APKType.APK/*, APKType.BUNDLE*/) // TEMPORARY: Only accept APKType.APK since Bundles are not currently supported
                 .also { if (preferSplit) it.reverse() }
 
             val variant = orderedAPKTypes.firstNotNullOfOrNull { apkType ->
                 supportedArches.firstNotNullOfOrNull { arch ->
-                    variants.find { it.arch == arch && it.apkType == APKType.APK } // TEMPORARY: Only accept APKType.APK since Bundles are not currently supported; replace APKType.APK with apkType once bundles are supported
+                    variants.find { it.arch == arch && it.apkType == apkType }
                 }
             } ?: throw Exception("No compatible variant found")
 


### PR DESCRIPTION
Temporarily only download non-bundled APKs from APKMirror since bundled APKs are not yet supported.

Currently when downloading from APKMirror, the patcher will crash with `Split apks are not supported yet` when downloading an apk bundle. This change should ensure that they aren't downloaded at all.
